### PR TITLE
Fixing #isTerminated

### DIFF
--- a/DebuggableASTInterpreter/DASTInterpreter.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreter.class.st
@@ -74,7 +74,7 @@ DASTInterpreter >> initializeWithProgram: aRBNode [
 { #category : #testing }
 DASTInterpreter >> isTerminated [
 	self flag: 'ToDo: is this method necessary?'.
-	^ self currentContext nodes isEmpty and: [self currentContext parent isRoot].
+	^ self currentContext isRoot.
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The current #isTerminated method does not seem to work.

Running the following in a playground raises a "#isRoot was sent to nil" exception because the execution has reached the root context and is asking whether its parent (nil) is root to decide whether the execution is terminated.
```Smalltalk
interpreter := DASTInterpreter new.
interpreter initializeWithProgram: (RBParser parseExpression: 'Point new').
[ interpreter isTerminated  ] whileFalse: [ interpreter stepInto ].
```

This pull request make #isTerminated simply check whether the current context is the root context. With it, the example above runs without signalling an exception.